### PR TITLE
TST: add basic output test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytester"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_suite_output(pytester):
+    result = pytester.runpytest("--regex", "dummy_regex")
+    actual_stdout = result.stdout.str()
+    expected_str1 = "pytest-regex selected"
+    expected_str2 = "tests to run for regex: dummy_regex"
+    assert expected_str1 in actual_stdout
+    assert expected_str2 in actual_stdout


### PR DESCRIPTION
* use the `pytester` fixture to test the basic test session output for `pytest-regex`; this is also
helpful for demonstrating how to write the plugin tests and is based on an example in `pytest-xdist` project testing