### PR TITLE
TST: expand testing

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,6 +2,18 @@ import pytest
 
 
 def test_suite_output(pytester):
+    # a few checks for the scenario where
+    # pytest-regex is installed as a plugin
+    # but NO usage of --regex on the pytest
+    # incantation
+    dummy_result = pytester.runpytest()
+    dummy_stdout = dummy_result.stdout.str()
+    assert "pytest-regex" in dummy_stdout
+    assert "dummy_regex" not in dummy_stdout
+    assert "regex-" in dummy_stdout
+
+    # next, check the use of the --regex option
+    # on the command line
     result = pytester.runpytest("--regex", "dummy_regex")
     actual_stdout = result.stdout.str()
     expected_str1 = "pytest-regex selected"


### PR DESCRIPTION
* `test_suite_output()` now also has a few checks for the scenario where the plugin is installed but `--regex` isn't actually used on the CLI