### PR TITLE
MAINT, TST: add basic tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=
+    py39,py310,py311
+[testenv]
+deps =
+    pytest>=7
+commands = pytest {posargs}


### PR DESCRIPTION
* it seems that upstreamed plugins are generally expected/required to use `tox` for testing, so add a basic config file for that, which seems to work well enough with `tox run` locally

* for reference see: 
  - https://docs.pytest.org/en/7.1.x/contributing.html#submitplugin
  - https://github.com/pytest-dev/pytest-xdist/blob/master/tox.ini